### PR TITLE
fix: hide alternate text when not configured

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -147,7 +147,10 @@ export function LoginForm({ className }: React.ComponentProps<"div">) {
                     </Button>
                 </Field>
 
-                <FieldSeparator>Or continue with</FieldSeparator>
+                {(env.NEXT_PUBLIC_GITHUB_ENABLED ||
+                    env.NEXT_PUBLIC_OAUTH_ENABLED) && (
+                    <FieldSeparator>Or continue with</FieldSeparator>
+                )}
 
                 {/* GitHub */}
                 <Field>

--- a/components/auth/signup-form.tsx
+++ b/components/auth/signup-form.tsx
@@ -259,7 +259,10 @@ export function SignupForm({
                     </Button>
                 </Field>
 
-                <FieldSeparator>Or continue with</FieldSeparator>
+                {(env.NEXT_PUBLIC_GITHUB_ENABLED ||
+                    env.NEXT_PUBLIC_OAUTH_ENABLED) && (
+                    <FieldSeparator>Or continue with</FieldSeparator>
+                )}
 
                 <Field>
                     {env.NEXT_PUBLIC_GITHUB_ENABLED && (


### PR DESCRIPTION
Fixes the issue where the alternative options were visible even tho nothing is configured.

closes #41 